### PR TITLE
[HAPI-101] Remove old module-alias/register importation from ServerAPI

### DIFF
--- a/src/services/ServerAPI/index.js
+++ b/src/services/ServerAPI/index.js
@@ -1,4 +1,3 @@
-require('module-alias/register');
 // Declaring globals
 require('../../global');
 


### PR DESCRIPTION
## [HAPI-101] Remove old module-alias/register importation from ServerAPI

[HAPI-101]: https://feliperamosdev.atlassian.net/browse/HAPI-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ