### PR TITLE
[HAPI-221] Doc Subscription is not using the UID when a filter is provided

### DIFF
--- a/src/services/ServerIO/SubscriberIO.js
+++ b/src/services/ServerIO/SubscriberIO.js
@@ -138,7 +138,6 @@ class SubscriberIO extends ServerIO {
             loadMethod
         }, this);
 
-        this.setDocSubscription(subscription);
         return subscription;
     }
 

--- a/src/services/ServerIO/SubscriptionIO.js
+++ b/src/services/ServerIO/SubscriptionIO.js
@@ -40,10 +40,10 @@ class SubscriptionIO {
                 if (typeof customMethod === 'function') {
                     customMethod.call(this);
                 } else {
-                    this.loadQuery();
+                    this.loadQuery().then(() => this.subscriber.setDocSubscription(this));
                 }
             } else {
-                this.loadQuery();
+                this.loadQuery().then(() => this.subscriber.setDocSubscription(this));
             }
         }
 
@@ -58,10 +58,10 @@ class SubscriptionIO {
                 if (typeof customMethod === 'function') {
                     customMethod.call(this);
                 } else {
-                    this.loadDoc();
+                    this.loadDoc().then(() => this.subscriber.setDocSubscription(this));
                 }
             } else {
-                this.loadDoc();
+                this.loadDoc().then(() => this.subscriber.setDocSubscription(this));
             }
         }
     }


### PR DESCRIPTION
## [HAPI-221] Description
Moved the setDocSubscription in order to get the UID on the loadDoc method to save the UID instead of filter