### PR TITLE
[HAPI-240] Changing the approach for not confirmed emails

### DIFF
--- a/src/collections/Models/users.model.js
+++ b/src/collections/Models/users.model.js
@@ -318,7 +318,7 @@ class User extends _Global {
      * @returns {Promise<User|Error>} - A promise resolving to the signed-in user object, or an error object if sign-in fails.
      * @throws {Error.Log} If there is an error during sign-in.
      */
-     static async signIn(userName, password, preventEmailConfirm) {
+     static async signIn(userName, password) {
         const CRUD = global._4handsAPI?.CRUD;
 
         try {
@@ -328,13 +328,6 @@ class User extends _Global {
                 return logError({
                     name: 'USER_NOT_FOUND',
                     message: `The user "${userName}" does not exist!`
-                });
-            }
-
-            if (!preventEmailConfirm && !userDOC.isEmailConfirmed) {
-                return logError({
-                    name: 'USER_EMAIL_NOT_CONFIRMED',
-                    message: `The user needs to confirm his email before login!`
                 });
             }
 

--- a/src/middlewares/authVerify.js
+++ b/src/middlewares/authVerify.js
@@ -10,11 +10,6 @@ const notConfirmedEmail = {
     message: `The user's e-mail is not confirmed!`
 };
 
-const badConfirmationToken = {
-    name: 'BAD_CONFIMATION_TOKEN',
-    message: `The confirmation token provided is not correct!`
-};
-
 module.exports = async (req, res, next) => {
     const { session, sessionStore, headers, body } = req;
     const authService = new AuthService();
@@ -40,7 +35,8 @@ module.exports = async (req, res, next) => {
         } else {
             if (!data.isEmailConfirmed) {
                 if (typeof body.confirmationtoken !== 'string') {
-                    return res.status(401).send(notConfirmedEmail);
+                    const error = toError(notConfirmedEmail);
+                    return res.status(201).send({ ...error, userName: data.user?.email });
                 }
                 
                 session.confirmationToken = data.confirmationToken;


### PR DESCRIPTION
## [HAPI-240] Description
Before and error was returned when the email is not confirmed, now it's success with the error

[HAPI-240]: https://feliperamosdev.atlassian.net/browse/HAPI-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ