### PR TITLE
[HAPI-242] Redis URL flexibility

### DIFF
--- a/src/models/settings/EventEndpoint.js
+++ b/src/models/settings/EventEndpoint.js
@@ -1,6 +1,6 @@
 const { logError } = require('4hands-api/src/models/ErrorLog');
-const IORedis = require('ioredis');
-const ioRedis = new IORedis();
+const IORedis = require('ioredis').default;
+const ioRedis = new IORedis(process.env.REDIS_URL);
 
 /**
  * Represents an API endpoint configuration.


### PR DESCRIPTION
## [HAPI-242] Description
This pull request updates the Redis client initialization in the `EventEndpoint` model to improve compatibility with the default export of the `ioredis` library and to support configurable Redis URLs.

Key changes:

* [`src/models/settings/EventEndpoint.js`](diffhunk://#diff-08792a48feba7f001ee3dedac694177d945c797292b9b7c9d9ec4e338faf90f9L2-R3): Updated the import statement to use the default export of `ioredis` and modified the `ioRedis` initialization to use the `REDIS_URL` environment variable for better configuration flexibility.

[HAPI-242]: https://feliperamosdev.atlassian.net/browse/HAPI-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ