### PR TITLE
[HAPI-244] Issue with password has creating

### DIFF
--- a/src/services/Auth/index.js
+++ b/src/services/Auth/index.js
@@ -135,7 +135,7 @@ class AuthService {
     async createHash(password, saltLength) {
         try {
             const salt = await this.genSalt(saltLength);
-            const hash = bcryptjs.hash(password, salt);
+            const hash = await bcryptjs.hash(password.toString(), salt);
             return hash;
         } catch (err) {
             throw logError(err);


### PR DESCRIPTION
## [HAPI-244] Description
This pull request includes a small but important fix in the `AuthService` class to ensure proper handling of the `password` parameter when generating a hash.

* [`src/services/Auth/index.js`](diffhunk://#diff-9bfde8ef08b67ca34f1e7cf9a2abe143edb137945dd08600dfe197baa7013ce3L138-R138): Updated the `createHash` method to explicitly convert the `password` parameter to a string before hashing, preventing potential issues with non-string inputs.

[HAPI-244]: https://feliperamosdev.atlassian.net/browse/HAPI-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ