### PR TITLE
[HAPI-249] Fixing Session Persistence Issues

### DIFF
--- a/src/collections/Models/users.model.js
+++ b/src/collections/Models/users.model.js
@@ -42,9 +42,6 @@ class User extends _Global {
             const user = await User.getUser(this._id);
 
             session.user = await user.toSession(session);
-            session.sessionSalt = session.sessionSalt;
-            session.isEmailConfirmed = user.isEmailConfirmed;
-            await session.save();
             return user;
         } catch (error) {
             throw logError(error);

--- a/src/controllers/auth/confirm-email.js
+++ b/src/controllers/auth/confirm-email.js
@@ -35,9 +35,7 @@ module.exports = new Endpoint({
                 return res.status(401).send(badConfirmationToken);
             }
 
-            await user.updateSession(req.session);
-            req.sessionID = req.session.id;
-            req.session.save((saveErr) => {
+            req.sessionStore.set(req.sessionID, req.session, (saveErr) => {
                 if (saveErr) return res.status(500).send(toError(saveErr));
                 res.status(200).send({ success: true });
             });

--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -38,7 +38,7 @@ module.exports = new Endpoint({
                 req.session.isAuthorized = true;
                 req.session.isEmailConfirmed = user.isEmailConfirmed;
 
-                req.session.save((saveErr) => {
+                req.sessionStore.set(req.sessionID, req.session, (saveErr) => {
                     if (saveErr) return res.status(500).send(toError(saveErr));
                     return next();
                 });

--- a/src/controllers/auth/register.js
+++ b/src/controllers/auth/register.js
@@ -46,7 +46,7 @@ module.exports = new Endpoint({
             req.session.isAuthorized = true;
             req.session.isEmailConfirmed = false;
 
-            req.session.save((saveErr) => {
+            req.sessionStore.set(req.sessionID, req.session, (saveErr) => {
                 if (saveErr) return res.status(500).send(logError(saveErr));
                 return res.status(200).send(response);
             });


### PR DESCRIPTION
## [HAPI-249] Description
This pull request refactors how user sessions are saved and updated across authentication-related controllers. Instead of using `req.session.save()`, the code now updates sessions directly in the session store with `req.sessionStore.set()`. Additionally, some redundant session property assignments have been removed from the user model.

**Session Management Refactoring:**

* Replaced `req.session.save()` with `req.sessionStore.set(req.sessionID, req.session, ...)` in the email confirmation, login, and registration controllers to ensure sessions are explicitly persisted in the session store. [[1]](diffhunk://#diff-e4c083695d075521de4d5082cabddeca0d3aa8551febdd2cce8447fcc0d8669bL38-R38) [[2]](diffhunk://#diff-2e5cbc6a12ddd6e83c902c918771879d26ce491443c97f6e850725a681b38dbdL41-R41) [[3]](diffhunk://#diff-a67719783e072feb2d344bd91154edde99408c7141fb6d16ea1150290564ffbaL49-R49)

**Code Cleanup:**

* Removed unnecessary assignments to `session.sessionSalt` and `session.isEmailConfirmed`, and the redundant session save call from the `User.updateSession` method in `users.model.js`.

[HAPI-249]: https://feliperamosdev.atlassian.net/browse/HAPI-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ