### PR TITLE
[HAPI-250] Upload Feature

### DIFF
--- a/client/models/Auth.js
+++ b/client/models/Auth.js
@@ -107,7 +107,16 @@ class Auth {
     */
    async signOut() {
       try {
-         return await this.instance.ajax.authPost('/auth/signout');
+         const result = await this.instance.ajax.authPost('/auth/signout');
+
+         // Clear the token cookie so subsequent requests don't carry a stale JWT.
+         if (typeof cookieStore !== 'undefined') {
+            await cookieStore.delete('token');
+         } else {
+            document.cookie = 'token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/';
+         }
+
+         return result;
       } catch (err) {
          if (err?.name === 'USER_NOT_AUTHORIZED') {
             return { isLogged: false };

--- a/client/services/AJAX.js
+++ b/client/services/AJAX.js
@@ -264,6 +264,58 @@ class AJAX {
    }
 
    /**
+    * Perform a file upload POST request using multipart/form-data.
+    * @param {string} endpoint - The API endpoint.
+    * @param {File|Blob} file - The file to upload.
+    * @param {Object} [fields={}] - Additional form fields (e.g. { bucket: 'avatars' }).
+    * @param {Object} [options={}] - The request options.
+    * @returns {Promise<Object>} The response data (FileMetadata).
+    */
+   async upload(endpoint, file, fields = {}, options = {}) {
+      const { isAuth, headers, onUploadProgress } = options;
+      let toHeaders = { ...headers };
+
+      try {
+         if (isAuth) {
+            toHeaders = await this.addToken(toHeaders);
+         }
+
+         const formData = new FormData();
+         formData.append('file', file);
+
+         Object.entries(fields).forEach(([key, value]) => {
+            formData.append(key, value);
+         });
+
+         const response = await axios.post(this.url(endpoint), formData, {
+            ...options,
+            httpAgent: this.httpAgent,
+            headers: {
+               ...toHeaders,
+               'Content-Type': 'multipart/form-data'
+            },
+            onUploadProgress
+         });
+
+         return response.data;
+      } catch (err) {
+         throw this.toError(err);
+      }
+   }
+
+   /**
+    * Perform an authenticated file upload POST request.
+    * @param {string} endpoint - The API endpoint.
+    * @param {File|Blob} file - The file to upload.
+    * @param {Object} [fields={}] - Additional form fields (e.g. { bucket: 'avatars' }).
+    * @param {Object} [options={}] - The request options.
+    * @returns {Promise<Object>} The response data (FileMetadata).
+    */
+   async authUpload(endpoint, file, fields = {}, options = {}) {
+      return this.upload(endpoint, file, fields, { ...options, isAuth: true });
+   }
+
+   /**
     * Convert an error to a standardized error object.
     * @param {Object} err - The error object.
     * @returns {Object} The standardized error object.

--- a/src/collections/Models/users.model.js
+++ b/src/collections/Models/users.model.js
@@ -184,7 +184,12 @@ class User extends _Global {
      * @returns {Object} - The public object representing the user information.
      */
     toPublic(append) {
-        const dataOut = {...this, ...append};
+        const dataOut = {
+            ...this,
+            fullName: this.fullName,
+            avatarUrl: this.avatarUrl,
+            ...append
+        };
 
         delete dataOut.auth;
         delete dataOut._schema;

--- a/src/io/subscribe.js
+++ b/src/io/subscribe.js
@@ -59,7 +59,7 @@ module.exports = SubscriberIO.buildSubscriber({
             querySubscriptions.map(sub => sub.exec('update', docSnapshot));
         }
 
-        const docUID = docSnapshot.id || docSnapshot.UID || docSnapshot._id;
+        const docUID = docSnapshot.id || docSnapshot.UID || docSnapshot._id || docSnapshot._doc?._id;
         const docSubscriptions = this.getDocSubscriptions(collection, docUID.toString());
         if (Array.isArray(docSubscriptions)) {
             docSubscriptions.map(sub => sub.exec('update', docSnapshot));

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,5 +1,7 @@
+const bodyValidation = require('4hands-api/src/middlewares/bodyValidation');
 const authVerify = require('./authVerify');
 
 module.exports = {
-    authVerify
+    authVerify,
+    bodyValidation
 };

--- a/src/services/ServerIO/SubscriptionIO.js
+++ b/src/services/ServerIO/SubscriptionIO.js
@@ -139,7 +139,7 @@ class SubscriptionIO {
         const socket = this.subscriber.getConnection(this.socketID);
 
         if (socket) {
-            socket.emit(this.id, data);
+            socket.emit(this.id, data?.toObject?.() || data);
         }
     }
 


### PR DESCRIPTION
## [HAPI-250] Description
This pull request introduces several improvements and fixes across authentication, file upload, user data serialization, subscription handling, and middleware registration. The most notable enhancements are the addition of file upload support in the AJAX service, improved JWT token cleanup on sign-out, and safer handling of user and subscription data.

**File Upload Enhancements**
* Added `upload` and `authUpload` methods to the `AJAX` service to support file uploads using `multipart/form-data`, including progress callbacks and authentication options.

**Authentication Improvements**
* In `Auth.signOut`, now explicitly deletes the JWT token cookie after sign-out to prevent stale tokens from being sent in future requests.

**User Data Serialization**
* Updated `User.toPublic` to always include `fullName` and `avatarUrl` fields in the public representation, ensuring these are exposed consistently.

**Subscription and Realtime Data Handling**
* Improved document UID extraction in the subscriber logic to handle more cases (including documents with nested `_doc._id` fields).
* Ensured that data sent over subscriptions is always a plain object by calling `toObject()` if available.

**Middleware Registration**
* Registered the `bodyValidation` middleware for use in the application.

[HAPI-250]: https://feliperamosdev.atlassian.net/browse/HAPI-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ